### PR TITLE
Pass driver options to color package

### DIFF
--- a/hyperref.dtx
+++ b/hyperref.dtx
@@ -147,7 +147,7 @@
 \end{document}
 %</driver>
 % \fi
-% \CheckSum{39767}
+% \CheckSum{39772}
 %
 % \MakeShortVerb{|}
 % \StopEventually{}
@@ -5370,6 +5370,7 @@
 \DeclareVoidOption{nativepdf}{%
   \HyOpt@CheckDvi{nativepdf}{%
     \def\Hy@driver{hdvips}%
+    \PassOptionsToPackage{dvips}{color}%
   }%
 }
 \DeclareVoidOption{dvipdfm}{%
@@ -5380,6 +5381,7 @@
 \DeclareVoidOption{dvipdfmx}{%
   \HyOpt@CheckDvi{dvipdfmx}{%
     \def\Hy@driver{hdvipdfm}%
+    \PassOptionsToPackage{dvipdfmx}{color}%
   }%
 }
 \define@key{Hyp}{dvipdfmx-outline-open}[true]{%
@@ -5408,6 +5410,7 @@
 \DeclareVoidOption{dvips}{%
   \HyOpt@CheckDvi{dvips}{%
     \def\Hy@driver{hdvips}%
+    \PassOptionsToPackage{dvipsone}{color}%
   }%
 }
 \DeclareVoidOption{hypertex}{%
@@ -5472,6 +5475,7 @@
 \DeclareVoidOption{dvipsone}{%
   \HyOpt@CheckDvi{dvipsone}{%
     \def\Hy@driver{hdvipson}%
+    \PassOptionsToPackage{dvipsone}{color}%
   }%
 }
 \DeclareVoidOption{textures}{%
@@ -5490,6 +5494,7 @@
 \DeclareVoidOption{ps2pdf}{%
   \HyOpt@CheckDvi{ps2pdf}{%
     \def\Hy@driver{hdvips}%
+    \PassOptionsToPackage{dvips}{color}%
   }%
 }
 %    \end{macrocode}

--- a/hyperref.dtx
+++ b/hyperref.dtx
@@ -5410,7 +5410,7 @@
 \DeclareVoidOption{dvips}{%
   \HyOpt@CheckDvi{dvips}{%
     \def\Hy@driver{hdvips}%
-    \PassOptionsToPackage{dvipsone}{color}%
+    \PassOptionsToPackage{dvips}{color}%
   }%
 }
 \DeclareVoidOption{hypertex}{%


### PR DESCRIPTION
I just happened to find this repository, and this can be the upstream for TeX Live: so I'd like to propose a patch (already reported to Heiko about a year ago, and then to [tex-live list](http://tug.org/pipermail/tex-live/2015-June/037082.html), but nothing happened).

The following code for png inclusion fails, since current implementation of graphics/color shares `\Gin@driver` files:
~~~~ tex
%#!latex -> dvipdfmx
\documentclass{article}
\usepackage[dvipdfmx]{graphicx}
\usepackage[dvipdfmx,colorlinks=true]{hyperref} % ng
%\usepackage[dvipdfmx]{hyperref} % ok
\begin{document}
\begin{figure}[t]
\includegraphics[width=0.2\linewidth]{tuglogo.png}
\end{figure}
TUG: \url{http://tug.org/}.
\end{document}
~~~~
When I remove `colorlinks=true`, the above code compiles correctly. If the hyperref package kindly calls color with the proper driver option, this problem will go away.