### PR TITLE
Fix spelling

### DIFF
--- a/ChangeLog.xml
+++ b/ChangeLog.xml
@@ -4,7 +4,7 @@
 
 <ENTRY date="2016-06-24" version="6.83q" by="&DC;">
 * 6.83q
-* cleverref support
+* cleveref support
 </ENTRY>
 
 <ENTRY date="2016-05-21" version="6.83p" by="&DC;">


### PR DESCRIPTION
[cleveref](https://www.ctan.org/pkg/cleveref?lang=de) is spelled without double `r`. This is the only place with that typo.