### PR TITLE
Document linktoc

### DIFF
--- a/doc/manual.tex
+++ b/doc/manual.tex
@@ -624,6 +624,7 @@ hyperindex     & boolean & true    & Makes the page numbers of index entries int
 hyperfootnotes & boolean & true    & Makes the footnote marks into hyperlinks to the footnote text.
                                      Easily broken \ldots\\
 encap          &         &         & Sets encap character for hyperindex \\
+linktoc        & text    & section & make text (\verb|section|), page number (\verb|page|), both (\verb|all|) or nothing (\verb|none|) be link on TOC, LOF and LOT \\
 linktocpage    & boolean & false   & make page number, not text, be link on TOC, LOF and LOT \\
 breaklinks     & boolean & false   & allow links to break over lines by making links over multiple lines into PDF links to
                                      the same target \\
@@ -884,6 +885,7 @@ implicit           & \textit{true}          & redefine \LaTeX\ internals \\
 latex2html         &                        & use \textsf{\LaTeX2HTML} backend \\
 linkbordercolor    & \textit{1 0 0}         & color of border around links \\
 linkcolor          & \textit{red}           & color of links \\
+linktoc            & \textit{section}       & make text be link on TOC, LOF and LOT \\
 linktocpage        & \textit{false}         & make page number, not text, be link on TOC, LOF and LOT \\
 menubordercolor    & \textit{1 0 0}         & color of border around menu links \\
 menucolor          & \textit{red}           & color for menu links \\


### PR DESCRIPTION
Hyperref supports an undocumented option `linktoc` with options `section`, `page`, `all`, and `none`. This PR adds a first documentation for it.

I cannot compile manual.tex (see below), but I assume, I got the syntax right.

```
! Undefined control sequence.
\meta  ... \font \m@ne \language \l@nohyphenation
                                                  #1\/\meta@hyphen@restore }...
l.521 \verb|\HyperDestRename{|\meta{destination}
                                                \verb|}{|\meta{newname}\verb|}|
```