### PR TITLE
code to amend issue #40 (missing pdfhighlight option for xetex/dvipdfmx)

### DIFF
--- a/hluatex.dtx
+++ b/hluatex.dtx
@@ -1,7 +1,7 @@
 % \iffalse
 %% Source File: hluatex.dtx
 %% Copyright 2016 Oberdiek Package Support Group
-%% 
+%%
 %%
 %% Derived from hpdftex.def
 %%
@@ -362,10 +362,7 @@
   \Hy@StartlinkName{%
     \ifHy@pdfa /F 4\fi
     \Hy@setpdfborder
-    \ifx\@pdfhighlight\@empty
-    \else
-      /H\@pdfhighlight
-    \fi
+    \Hy@setpdfhighlight
     \ifx\CurrentBorderColor\relax
     \else
       /C[\CurrentBorderColor]%
@@ -421,10 +418,7 @@
     \pdfstartlink
       attr{%
         \Hy@setpdfborder
-        \ifx\@pdfhightlight\@empty
-        \else
-          /H\@pdfhighlight
-        \fi
+        \Hy@setpdfhighlight
         \ifx\@urlbordercolor\relax
         \else
           /C[\@urlbordercolor]%
@@ -459,10 +453,7 @@
     \pdfstartlink
       attr{%
         \Hy@setpdfborder
-        \ifx\@pdfhighlight\@empty
-        \else
-          /H\@pdfhighlight
-        \fi
+        \Hy@setpdfhighlight
         \ifx\@filebordercolor\relax
         \else
           /C[\@filebordercolor]%
@@ -496,10 +487,7 @@
     \pdfstartlink
       attr{%
         \Hy@setpdfborder
-        \ifx\@pdfhighlight\@empty
-        \else
-          /H\@pdfhighlight
-        \fi
+        \Hy@setpdfhighlight
         \ifx\@runbordercolor\relax
         \else
           /C[\@runbordercolor]%
@@ -781,10 +769,7 @@
     \pdfstartlink
       attr{%
         \Hy@setpdfborder
-        \ifx\@pdfhighlight\@empty
-        \else
-          /H\@pdfhighlight
-        \fi
+        \Hy@setpdfhighlight
         \ifx\@menubordercolor\relax
         \else
           /C[\@menubordercolor]%

--- a/hyperref.dtx
+++ b/hyperref.dtx
@@ -6390,6 +6390,12 @@
   \do{/O}{Outline}%
   \do{/P}{Push}%
 }
+\def\Hy@setpdfhighlight{%
+  \ifx\@pdfhighlight\@empty
+  \else
+    /H\@pdfhighlight
+  \fi
+}
 \define@key{Hyp}{pdfborder}{%
   \let\Hy@temp\@pdfborder
   \def\@pdfborder{#1}%
@@ -13820,10 +13826,7 @@
   \Hy@StartlinkName{%
     \ifHy@pdfa /F 4\fi
     \Hy@setpdfborder
-    \ifx\@pdfhighlight\@empty
-    \else
-      /H\@pdfhighlight
-    \fi
+    \Hy@setpdfhighlight
     \ifx\CurrentBorderColor\relax
     \else
       /C[\CurrentBorderColor]%
@@ -13879,10 +13882,7 @@
     \pdfstartlink
       attr{%
         \Hy@setpdfborder
-        \ifx\@pdfhighlight\@empty
-        \else
-          /H\@pdfhighlight
-        \fi
+        \Hy@setpdfhighlight
         \ifx\@urlbordercolor\relax
         \else
           /C[\@urlbordercolor]%
@@ -13917,10 +13917,7 @@
     \pdfstartlink
       attr{%
         \Hy@setpdfborder
-        \ifx\@pdfhighlight\@empty
-        \else
-          /H\@pdfhighlight
-        \fi
+        \Hy@setpdfhighlight
         \ifx\@filebordercolor\relax
         \else
           /C[\@filebordercolor]%
@@ -13968,10 +13965,7 @@
     \pdfstartlink
       attr{%
         \Hy@setpdfborder
-        \ifx\@pdfhighlight\@empty
-        \else
-          /H\@pdfhighlight
-        \fi
+        \Hy@setpdfhighlight
         \ifx\@runbordercolor\relax
         \else
           /C[\@runbordercolor]%
@@ -14382,10 +14376,7 @@
     \pdfstartlink
       attr{%
         \Hy@setpdfborder
-        \ifx\@pdfhighlight\@empty
-        \else
-          /H\@pdfhighlight
-        \fi
+        \Hy@setpdfhighlight
         \ifx\@menubordercolor\relax
         \else
           /C[\@menubordercolor]%

--- a/hyperref.dtx
+++ b/hyperref.dtx
@@ -15115,6 +15115,7 @@
         /Subtype/Link%
         \ifHy@pdfa /F 4\fi
         \Hy@setpdfborder
+        \Hy@setpdfhighlight
         \expandafter\ifx\csname @#1bordercolor\endcsname\relax
         \else
           /C[\csname @#1bordercolor\endcsname]%
@@ -15147,6 +15148,7 @@
         /Subtype/Link%
         \ifHy@pdfa /F 4\fi
         \Hy@setpdfborder
+        \Hy@setpdfhighlight
         \ifx\@filebordercolor\relax
         \else
           /C[\@filebordercolor]%
@@ -15181,6 +15183,7 @@
         /Subtype/Link%
         \ifHy@pdfa /F 4\fi
         \Hy@setpdfborder
+        \Hy@setpdfhighlight
         \ifx\@runbordercolor\relax
         \else
           /C[\@runbordercolor]%
@@ -15212,6 +15215,7 @@
         /Subtype/Link%
         \ifHy@pdfa /F 4\fi
         \Hy@setpdfborder
+        \Hy@setpdfhighlight
         \ifx\@urlbordercolor\relax
         \else
           /C[\@urlbordercolor]%
@@ -15241,6 +15245,7 @@
           /Subtype/Link%
           \ifHy@pdfa /F 4\fi
           \Hy@setpdfborder
+          \Hy@setpdfhighlight
           \ifx\@menubordercolor\relax
           \else
             /C[\@menubordercolor]%

--- a/hyperref.dtx
+++ b/hyperref.dtx
@@ -13879,7 +13879,7 @@
     \pdfstartlink
       attr{%
         \Hy@setpdfborder
-        \ifx\@pdfhightlight\@empty
+        \ifx\@pdfhighlight\@empty
         \else
           /H\@pdfhighlight
         \fi


### PR DESCRIPTION
I defined and used  `\Hy@setpdfhighlight` in analogy to  `\Hy@setpdfborder`. I also replaced in the pdftex and luatex driver the \if-\fi by this command (there was a typo in hpdftex.def anyway).