### PR TITLE
issue #25, added  \HyPsd@EscapeTeX#1% 

### DIFF
--- a/hyperref.dtx
+++ b/hyperref.dtx
@@ -1926,6 +1926,7 @@
               \Hy@unicodefalse
             }{%
               \HyPsd@ToBigChars#1%
+              \HyPsd@EscapeTeX#1%
             }%
           \else
             \StringEncodingConvertTest\HyPsd@temp\HyPsd@temp


### PR DESCRIPTION
to correctly escape non-ascii in heading with xetex. 
See https://github.com/ho-tex/hyperref/issues/25#issuecomment-300095380