### PR TITLE
Issue #38: change version to 1.4 with pdfa only if it is smaller

### DIFF
--- a/hyperref.dtx
+++ b/hyperref.dtx
@@ -7182,7 +7182,9 @@
 %
 %    \begin{macrocode}
 \ifHy@pdfa
+  \ifnum \Hy@pdfversion < 4
   \kvsetkeys{Hyp}{pdfversion=1.4}%
+  \fi
   \Hy@DisableOption{pdfversion}%
   \def\Hy@Acrobatmenu#1#2{%
     \leavevmode

--- a/hyperref.dtx
+++ b/hyperref.dtx
@@ -5309,7 +5309,7 @@
 \@namedef{Hy@pdfversion@1.7}{7}%
 \@namedef{Hy@pdfversion@1.8}{8}%
 \@namedef{Hy@pdfversion@1.9}{9}%
-\def\Hy@pdfversion{2}
+\def\Hy@pdfversion{5}
 %    \end{macrocode}
 %
 % \section{Options for different drivers}\label{drivers}


### PR DESCRIPTION
I suggest two changes: 

the default version value of hyperref should be changed to 5 to be in sync with the default value in the current tex systems. Imho this shouldn't change much, only together with the second change  the `pdfa` key will give  1.5 instead of 1.4 if the version is not set explicitly to something else.

And I added a test so that `pdfa sets` the version to 1.4 only if it is currently smaller.

Side remark: the key `pdfversion` doesn't do anything currently with xetex/dvipdfmx. This could be changed. It could add `\special{pdf:minorversion \Hy@pdfversion}`, but this would overwrite the -V command line option. I'm not quite sure if nobody will complain.