### PR TITLE
don't define \noboundary as text command / issue 37

### DIFF
--- a/hyperref.dtx
+++ b/hyperref.dtx
@@ -7182,7 +7182,9 @@
 %
 %    \begin{macrocode}
 \ifHy@pdfa
+  \ifnum \Hy@pdfversion < 4
   \kvsetkeys{Hyp}{pdfversion=1.4}%
+  \fi
   \Hy@DisableOption{pdfversion}%
   \def\Hy@Acrobatmenu#1#2{%
     \leavevmode

--- a/hyperref.dtx
+++ b/hyperref.dtx
@@ -1247,8 +1247,8 @@
     \let\P\textparagraph
     \let\ldots\textellipsis
     \let\dots\textellipsis
-    \ltx@IfUndefined{textEncodingNoboundary}
-      {}{\let\noboundary\textEncodingNoboundary}
+    \ltx@IfUndefined{textEncodingNoboundary}%
+      {}{\let\noboundary\textEncodingNoboundary}%
 %    \end{macrocode}
 %
 % \paragraph{Newline}

--- a/hyperref.dtx
+++ b/hyperref.dtx
@@ -5309,7 +5309,7 @@
 \@namedef{Hy@pdfversion@1.7}{7}%
 \@namedef{Hy@pdfversion@1.8}{8}%
 \@namedef{Hy@pdfversion@1.9}{9}%
-\def\Hy@pdfversion{2}
+\def\Hy@pdfversion{5}
 %    \end{macrocode}
 %
 % \section{Options for different drivers}\label{drivers}

--- a/hyperref.dtx
+++ b/hyperref.dtx
@@ -1231,6 +1231,9 @@
 %    There are several commands that prints characters in the
 %    printable ASCII area that don't obey the NFSS, so they have
 %    to be redefined here.
+%    UF 29.09.2017: added a mapping for \noboundary, see issue #37
+%    https://github.com/ho-tex/hyperref/issues/37
+%    No test for PU, if some definition for PD1 is added it will work too.
 %    \begin{macrocode}
     \let\{\textbraceleft
     \let\}\textbraceright
@@ -1244,6 +1247,8 @@
     \let\P\textparagraph
     \let\ldots\textellipsis
     \let\dots\textellipsis
+    \ltx@IfUndefined{textEncodingNoboundary}
+      {}{\let\noboundary\textEncodingNoboundary}
 %    \end{macrocode}
 %
 % \paragraph{Newline}
@@ -26419,7 +26424,7 @@
 % U+200C ZERO WIDTH NON-JOINER; afii61664
 \DeclareTextCommand{\ZWNJ}{PU}{\9040\014}% U+200C
 % U+200D ZERO WIDTH JOINER; afii301
-\DeclareTextCommand{\noboundary}{PU}{\9040\015}% U+200D
+\DeclareTextCommand{\textEncodingNoboundary}{PU}{\9040\015}% U+200D
 %    \end{macrocode}
 %    \begin{macrocode}
 %</puarenc>


### PR DESCRIPTION
Reference https://github.com/ho-tex/hyperref/issues/37

This removes the definition of \noboundary as a textcommand. Instead \textEncodingNoboundary is defined, and \noboundary is mappped locally in \pdfstringdef to this new command.

\noboundary is defined in two other files: latex/arabi/puenc-ar.def and 
latex/pdfx/l8uenc.def. They should adapt their code too. 

The other commands mentioned in the issue are imho not solely hyperrefs problem and so difficult to correct without cooperation of the other packages. 

(I messed up the commit history as I forgot to create a branch on the last pull request, sorry ..., but I have no idea if I can repair it without making it more messy) 

