### PR TITLE
Dutch language \autoref support

### DIFF
--- a/hyperref.dtx
+++ b/hyperref.dtx
@@ -6004,6 +6004,26 @@
     \def\pageautorefname{\textsigma\textepsilon\textlambda\acctonos\textiota\textdelta\textalpha}%
 }
 %    \end{macrocode}
+%    \begin{macrocode}
+\def\HyLang@dutch{%
+    \def\equationautorefname{Vergelijking}%
+    \def\footnoteautorefname{voetnoot}%
+    \def\itemautorefname{punt}%
+    \def\figureautorefname{Figuur}%
+    \def\tableautorefname{Tabel}%
+    \def\partautorefname{Deel}%
+    \def\appendixautorefname{Bijlage}%
+    \def\chapterautorefname{hoofdstuk}%
+    \def\sectionautorefname{paragraaf}%
+    \def\subsectionautorefname{deelparagraaf}%
+    \def\subsubsectionautorefname{deeldeelparagraaf}%
+    \def\paragraphautorefname{alinea}%
+    \def\subparagraphautorefname{deelalinea}%
+    \def\FancyVerbLineautorefname{lijn}%
+    \def\theoremautorefname{Stelling}%
+    \def\pageautorefname{pagina}%
+}
+%    \end{macrocode}
 %
 %    Instead of package babel's definition of \cmd{\addto} the
 %    implementation of package varioref is used. Additionally
@@ -6080,6 +6100,7 @@
 \HyLang@DeclareLang{magyar}{magyar}{}
 \HyLang@DeclareLang{hungarian}{magyar}{}
 \HyLang@DeclareLang{greek}{greek}{}
+\HyLang@DeclareLang{dutch}{dutch}{}
 %    \end{macrocode}
 %    More work is needed in case of options |vietnamese| and |vietnam|.
 %    \begin{macrocode}

--- a/hyperref.dtx
+++ b/hyperref.dtx
@@ -6016,10 +6016,10 @@
     \def\chapterautorefname{hoofdstuk}%
     \def\sectionautorefname{paragraaf}%
     \def\subsectionautorefname{deelparagraaf}%
-    \def\subsubsectionautorefname{deeldeelparagraaf}%
+    \def\subsubsectionautorefname{deel-deelparagraaf}%
     \def\paragraphautorefname{alinea}%
     \def\subparagraphautorefname{deelalinea}%
-    \def\FancyVerbLineautorefname{lijn}%
+    \def\FancyVerbLineautorefname{regel}%
     \def\theoremautorefname{Stelling}%
     \def\pageautorefname{pagina}%
 }


### PR DESCRIPTION
Hi there! I'd like to contribute Dutch translations for `\autoref` names. Would you be interested in that?

If so, I translated all of the English `\*autorefname` definitions (with some help from my friend @lynn), wrapped them into a definition of `\HyLang@dutch` and added that to `hyperref.dtx`, based on [this commit](https://github.com/ho-tex/hyperref/commit/de4100b047195a1451163a8fd3c149eedd2b709b). is that alright?

I tested the Dutch translations by explicitly including them in a `.tex` file, quoted below (as per the discussion in #52). However, I haven't tested them yet by importing my fork of the hyperref package directly&mdash;I've never contributed to any TeX packages before so I don't really know how to compile and locally install packages.

```tex
\documentclass{article}
\usepackage[dutch]{babel}
\usepackage[utf8]{inputenc}

\makeatletter
\def\HyLang@dutch{%
	\def\equationautorefname{Vergelijking}%
	\def\footnoteautorefname{voetnoot}%
	\def\itemautorefname{punt}%
	\def\figureautorefname{Figuur}%
	\def\tableautorefname{Tabel}%
	\def\partautorefname{Deel}%
	\def\appendixautorefname{Bijlage}%
	\def\chapterautorefname{hoofdstuk}%
	\def\sectionautorefname{paragraaf}%
	\def\subsectionautorefname{deelparagraaf}%
	\def\subsubsectionautorefname{deel-deelparagraaf}%
	\def\paragraphautorefname{alinea}%
	\def\subparagraphautorefname{deelalinea}%
	\def\FancyVerbLineautorefname{regel}%
	\def\theoremautorefname{Stelling}%
	\def\pageautorefname{pagina}%
}
\g@addto@macro\extrasdutch\HyLang@dutch
\makeatother

\usepackage{hyperref}

\begin{document}
\section{Test}
\label{sec:here}

\begin{figure}
\caption{\label{fig:here} foo bar}
\end{figure}

\autoref{sec:here}

\autoref{fig:here}
\end{document}
```

I hope you'll consider this PR for inclusion in hyperref. Thanks!