### PR TITLE
Add map of \mu to \psdmapshortnames

### DIFF
--- a/hyperref.dtx
+++ b/hyperref.dtx
@@ -22844,8 +22844,8 @@
 \DeclareTextCommand{\textkappa}{PU}{\83\272}%* U+03BA
 % U+03BB GREEK SMALL LETTER LAMDA; lambda; \lambda (LaTeX)
 \DeclareTextCommand{\textlambda}{PU}{\83\273}%* U+03BB
-% U+03BC GREEK SMALL LETTER MU; mu, *mu; \mu (LaTeX)
-\DeclareTextCommand{\textmu}{PU}{\83\274}%* U+03BC
+% U+03BC GREEK SMALL LETTER MU; mugreek, *mu; \mu (LaTeX)
+\DeclareTextCommand{\textmugreek}{PU}{\83\274}%* U+03BC
 % U+03BD GREEK SMALL LETTER NU; nu; \nu (LaTeX)
 \DeclareTextCommand{\textnu}{PU}{\83\275}%* U+03BD
 % U+03BE GREEK SMALL LETTER XI; xi; \xi (LaTeX)
@@ -26577,6 +26577,7 @@
   \let\kappa\textkappa
   \let\lambda\textlambda
   \let\mu\textmu
+  \let\mugreek\textmugreek
   \let\nu\textnu
   \let\xi\textxi
   \let\pi\textpi

--- a/hyperref.dtx
+++ b/hyperref.dtx
@@ -22844,8 +22844,8 @@
 \DeclareTextCommand{\textkappa}{PU}{\83\272}%* U+03BA
 % U+03BB GREEK SMALL LETTER LAMDA; lambda; \lambda (LaTeX)
 \DeclareTextCommand{\textlambda}{PU}{\83\273}%* U+03BB
-% U+03BC GREEK SMALL LETTER MU; mugreek, *mu; \mu (LaTeX)
-\DeclareTextCommand{\textmugreek}{PU}{\83\274}%* U+03BC
+% U+03BC GREEK SMALL LETTER MU; mu, *mu; \mu (LaTeX)
+\DeclareTextCommand{\textmu}{PU}{\83\274}%* U+03BC
 % U+03BD GREEK SMALL LETTER NU; nu; \nu (LaTeX)
 \DeclareTextCommand{\textnu}{PU}{\83\275}%* U+03BD
 % U+03BE GREEK SMALL LETTER XI; xi; \xi (LaTeX)
@@ -26576,7 +26576,7 @@
   \let\iota\textiota
   \let\kappa\textkappa
   \let\lambda\textlambda
-  \let\mugreek\textmugreek
+  \let\mu\textmu
   \let\nu\textnu
   \let\xi\textxi
   \let\pi\textpi


### PR DESCRIPTION
Currently, `hyperref`
 - provides text command `\textmugreek`, and then
 - relates it to math symbol `\mugreek` in `psdextra` option

But actually, there is not any command named `\mugreek`, neither in LaTeX2e kernel and `amsmath` bundle, nor in *The Comprehensive LaTeX Symbol List*. Therefore I suppose it is a typo.

This typo causes problems when you use 

```latex
\documentclass{article}
\usepackage[unicode,psdextra]{hyperref}
\usepackage{unicode-math}

\begin{document}
\section{$\lambda$} % all right
\section{$\mu$}     % "Improper alphabetic constant" error
\end{document}
```

even you have set up `hyperref` according to [this answer](https://tex.stackexchange.com/a/69354/79060) on tex.sx.

------

Hence this pull request is an attempt to fix this.